### PR TITLE
Add simple blender_manifest.toml and __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,105 @@
+import json
+from typing import Set
+
+import bpy
+from bpy.props import StringProperty
+from bpy.types import Context, Operator
+from bpy_extras.io_utils import ExportHelper, ImportHelper
+
+
+class ImportIIIF3DManifest(Operator, ImportHelper):
+    """Import IIIF 3D Manifest"""
+
+    bl_idname = "import.iiif_manifest"
+    bl_label = "Import IIIF 3D Manifest"
+
+    filename_ext = ".json"
+    filter_glob: StringProperty( # type: ignore
+        default="*.json",
+        options={"HIDDEN"}
+    )
+    filepath: StringProperty( # type: ignore
+        name="File Path",
+        description="Path to the input file",
+        maxlen=1024,
+        subtype='FILE_PATH',
+    )
+
+    def execute(self, context: Context) -> Set[str]:
+        try:
+            with open(self.filepath, 'r', encoding='utf-8') as f:
+                manifest_data = json.load(f)
+
+            self.report({'INFO'}, f"Successfully imported manifest from {self.filepath}")
+            self.report({'INFO'}, f"Manifest data: {manifest_data}")
+
+            return {'FINISHED'}
+
+        except Exception as e:
+            self.report({'ERROR'}, f"Error reading manifest: {str(e)}")
+            return {'CANCELLED'}
+
+class ExportIIIF3DManifest(Operator, ExportHelper):
+    """Export scene information as JSON"""
+
+    bl_idname = "export.scene_json"
+    bl_label = "Export Scene JSON"
+
+    filename_ext = ".json"
+    filter_glob: StringProperty( # type: ignore
+        default="*.json",
+        options={"HIDDEN"}
+    )
+    filepath: StringProperty( # type: ignore
+        name="File Path",
+        description="Path to the output file",
+        maxlen=1024,
+        subtype='FILE_PATH',
+    )
+
+    def execute(self, context: Context) -> Set[str]:
+        manifest_data = {
+            "@context": "http://iiif.io/api/presentation/4/context.json",
+            "id": "https://example.org/iiif/3d/model_origin.json",
+            "type": "Manifest",
+            "label": {"en": ["Example Manifest"]},
+            "summary": {"en": ["An example manifest"]},
+            "items": [],
+        }
+        try:
+            with open(self.filepath, "w", encoding="utf-8") as f:
+                json.dump(manifest_data, f, indent=4)
+        except Exception as e:
+            self.report({"ERROR"}, f"Error writing JSON file: {str(e)}")
+            return {"CANCELLED"}
+
+        self.report({"INFO"}, f"Successfully exported JSON to {self.filepath}")
+        return {"FINISHED"}
+
+def menu_func_import(self, context):
+    self.layout.operator(
+        ImportIIIF3DManifest.bl_idname, text="IIIF 3D Manifest (.json)"
+    )
+
+def menu_func_export(self, context):
+    self.layout.operator(
+        ExportIIIF3DManifest.bl_idname, text="IIIF 3D Manifest (.json)"
+    )
+
+
+def register():
+    bpy.utils.register_class(ImportIIIF3DManifest)
+    bpy.utils.register_class(ExportIIIF3DManifest)
+    bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
+    bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
+
+
+def unregister():
+    bpy.utils.unregister_class(ImportIIIF3DManifest)
+    bpy.utils.unregister_class(ExportIIIF3DManifest)
+    bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
+    bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
+
+
+if __name__ == "__main__":
+    register()

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,0 +1,31 @@
+schema_version = "1.0.0"
+
+id = "blender_iiif_3d_plugin"
+name = "Blender IIIF Manifest Import/Export"
+version = "1.0.0"
+tagline = "Import or export IIIF manifests"
+maintainer = "Developer name <email@address.com>"
+
+type = "add-on"
+
+website = "https://github.com/IIIF-Commons/3d-blender-plugin"
+
+tags = ["Import-Export"]
+
+blender_version_min = "4.2.0"
+
+license = ["SPDX:GPL-3.0-or-later"]
+
+[permissions]
+network = "Load models defined in IIIF manifests from the web"
+files = "Import/export IIIF manifests from/to the filesystem"
+
+[build]
+paths_exclude_pattern = [
+    "__pycache__/",
+    "/.git/",
+    "/*.zip",
+    "venv",
+    "assets",
+    ".gitignore",
+]


### PR DESCRIPTION
This PR registers a skeleton python script with IO as a simple extension according to the Blender 4.2 extension architecture (meaning an extension that can be packaged, which includes an add-on with the IO functionalities)

This closes https://github.com/IIIF-Commons/3d-blender-plugin/issues/1

Basic IO working
![Screenshot From 2024-11-06 21-11-03](https://github.com/user-attachments/assets/c0da2c1d-7590-4866-86e3-1ba68b3fea2b)

View inside of Preferences -> (Get) Extensions
![Screenshot From 2024-11-06 21-12-30](https://github.com/user-attachments/assets/8157444e-c5de-4726-8e42-81f22a8c87ae)

View inside of Preferences -> Add-ons
![Screenshot From 2024-11-06 21-12-41](https://github.com/user-attachments/assets/d6c10d0f-aa8d-4730-a720-ca982b77c84e)

Menu entries for importing and exporting
![Screenshot From 2024-11-06 21-12-51](https://github.com/user-attachments/assets/b396acdf-9312-498a-800e-015743fbbbe7)
![Screenshot From 2024-11-06 21-12-57](https://github.com/user-attachments/assets/8816b576-e23f-45dc-a5b9-7032528930ec)

